### PR TITLE
Add NodeJS nutsAuth API library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -482,6 +482,22 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        }
+      }
+    },
     "babel-loader": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
@@ -1510,6 +1526,29 @@
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "for-in": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "webpack-cli": "^3.3.6"
   },
   "dependencies": {
+    "axios": "^0.19.0",
     "qrcode": "^1.4.1"
   }
 }

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,0 +1,197 @@
+import QRCode from 'qrcode'
+
+export function init(config) {
+  // set default config values
+
+  // the url of the nuts-auth server
+  config.nutsAuthUrl = 'nutsAuthUrl' in config ? config.nutsAuthUrl : 'http://localhost:1323';
+  // which element to show the qrCode in
+  config.qrEl = 'qrEl' in config ? config.qrEl : 'qrCode';
+  // log login results to console.log
+  config.logLevel = 'logLevel' in config ? config.logLevel : 'none';
+  // on success, post token to which path?
+  config.postTokenPath = 'postTokenPath' in config ? config.postTokenPath : '/login';
+  // location for the browser to navigate to after success
+  config.afterSuccessPath = 'afterSuccessPath' in config ? config.afterSuccessPath : '/user';
+
+  // Check if qrCode element can be found
+  if (!document.getElementById(config.qrEl)) {
+    throw(`Could not load qr code: element with id ${config.qrEl} not found!`);
+  }
+
+  const fetchStatus = function (sessionId) {
+    return fetch(`${config.nutsAuthUrl}/auth/contract/session/${sessionId}`, {
+      method: 'GET',
+      mode: 'cors',
+      headers: {"Content-Type": "application/json"},
+      cache: 'reload'
+    }).then((result) => result.json())
+  };
+
+  // Handy helper with information about how to use IRMA
+  const showHelper = function () {
+    document.querySelector('.irma-web-form .header').classList.add('show-helper');
+  };
+
+  const hideHelper = function () {
+    document.querySelector('.irma-web-form .header').classList.remove('show-helper');
+  };
+
+
+  const setQrCode = (qrCodeInfo) => {
+    const canvasEl = document.getElementById(config.qrEl);
+    const qrCodeString = JSON.stringify(qrCodeInfo);
+    QRCode.toCanvas(canvasEl, qrCodeString, {width: 350});
+  };
+
+  const start = function () {
+    // show helper after 20 seconds
+    setTimeout(showHelper, 20000);
+
+    setState(WAIT_FOR_QR_CODE);
+
+    // Check if there is a previous unfinished session.
+    // This can happen if the page got reloaded during a session
+    let existingSessionInit = JSON.parse(localStorage.getItem('session_init_info'));
+    if (existingSessionInit) {
+      setQrCode(existingSessionInit.qr_code_info);
+      pollForStatus(existingSessionInit.session_id);
+      return;
+    }
+
+    let postData = {
+      type: "BehandelaarLogin",
+      language: "NL",
+      version: "v1"
+    };
+
+    fetch(`${config.nutsAuthUrl}/auth/contract/session`, {
+      method: 'POST',
+      mode: 'cors',
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify(postData),
+      cache: 'reload'
+    }).then((result) => {
+      if (result.status !== 201) {
+        throw "error while creating signing session";
+      } else {
+        return result.json(); // returns a promise
+      }
+    }).then((parsedResult) => {
+      setQrCode(parsedResult.qr_code_info);
+      localStorage.setItem('session_init_info', JSON.stringify(parsedResult));
+      pollForStatus(parsedResult.session_id);
+
+    }).catch((err) => {
+        console.log("err", err);
+        stateMachine("ERROR");
+      }
+    );
+  };
+
+  const pollForStatus = function (sessionId) {
+    fetchStatus(sessionId)
+      .then((status) => {
+        if (config.logLevel === 'debug') {
+          console.log("state:", status);
+        }
+        stateMachine(status);
+      }).catch((err) => {
+        console.log(err);
+        stateMachine("ERROR");
+      }
+    )
+  };
+
+  // handle these cases: https://godoc.org/github.com/privacybydesign/irmago/server#Status
+  // Set state, poll for status while not in final state
+  // Clear local storage when in final staten (failure or success)
+  const stateMachine = function (status) {
+    switch (status.status) {
+      case "INITIALIZED":
+        setState(INITIALIZED_STATE);
+        setTimeout(() => pollForStatus(status.token), 1000);
+        break;
+      case "CONNECTED":
+        setState(WAITING_FOR_USER_STATE);
+        setTimeout(() => pollForStatus(status.token), 1000);
+        break;
+      case "TIMEOUT":
+        localStorage.clear();
+        setState(EXPIRED_STATE);
+        break;
+      case "CANCELLED":
+        localStorage.clear();
+        setState(CANCELLED_STATE);
+        break;
+      case "DONE":
+        localStorage.clear();
+        if (status.proofStatus === "VALID") {
+          setState(SUCCESS_STATE);
+          handleSuccess(status);
+        } else {
+          setState(ERROR_STATE);
+        }
+        break;
+      case "ERROR":
+      default:
+        localStorage.clear();
+        setState(ERROR_STATE);
+        break;
+    }
+  };
+
+  const handleSuccess = function (status) {
+    fetch(config.postTokenPath, {
+      method: 'POST',
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({nuts_auth_token: status.nuts_auth_token}),
+      cache: 'reload',
+      json: true
+    }).then((res) => {
+      if (config.logLevel === 'debug') {
+        console.log("result", res);
+      }
+      if (res.status === 200) {
+        // show success state for 2 seconds before continuing
+        setTimeout(() => window.location = config.afterSuccessPath, 2000)
+      } else {
+        setState(ERROR_STATE);
+      }
+    }).catch((err) => {
+      setState(ERROR_STATE);
+      console.log("error while validating session", err);
+    })
+  };
+
+  const WAIT_FOR_QR_CODE = 'loading';
+  const INITIALIZED_STATE = 'initialized';
+  const WAITING_FOR_USER_STATE = 'waiting-for-user';
+  const SUCCESS_STATE = 'success';
+  const EXPIRED_STATE = 'expired';
+  const CANCELLED_STATE = 'cancelled';
+  const ERROR_STATE = 'errored';
+
+  // let currentState;
+
+  const stateEl = function (state) {
+    return document.querySelector(`.irma-web-form .content .${state}`)
+  };
+
+  const setState = function (state) {
+    // currentState = state;
+    hideAllStates();
+    stateEl(state).style.display = ""
+  };
+
+  const hideAllStates = function () {
+    document.querySelectorAll(`.irma-web-form .content .centered`).forEach((el) => {
+      el.style.display = 'none'
+    })
+  };
+
+  return {
+    hideHelper,
+    start,
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,185 +1,30 @@
-import QRCode from 'qrcode'
+import axios from 'axios';
 
-export function init(config) {
-  // set default config values
+const client = (serverAddress, actingPartyCN) => {
 
-  // the url of the nuts-auth server
-  config.nutsAuthUrl = 'nutsAuthUrl' in config ? config.nutsAuthUrl : 'http://localhost:1323';
-  // which element to show the qrCode in
-  config.qrEl = 'qrEl' in config ? config.qrEl : 'qrCode';
-  // log login results to console.log
-  config.logLevel = 'logLevel' in config ? config.logLevel : 'none';
-  // on success, post token to which path?
-  config.postTokenPath = 'postTokenPath' in config ? config.postTokenPath : '/login';
-  // location for the browser to navigate to after success
-  config.afterSuccessPath = 'afterSuccessPath' in config ? config.afterSuccessPath : '/user';
-
-  if (!document.getElementById(config.qrEl)) {
-    throw(`Could not load qr code: element with id ${config.qrEl} not found!`);
-  }
-
-  const fetchStatus = function (sessionId) {
-    return fetch(`${config.nutsAuthUrl}/auth/contract/session/${sessionId}`, {
-      method: 'GET',
-      mode: 'cors',
-      headers: {"Content-Type": "application/json"},
-      cache: 'reload'
-    }).then((result) => result.json())
-  };
-
-  const showHelper = function () {
-    document.querySelector('.irma-web-form .header').classList.add('show-helper');
-  };
-
-  const hideHelper = function () {
-    document.querySelector('.irma-web-form .header').classList.remove('show-helper');
-  };
-
-
-  const setQrCode= (qrCodeInfo) => {
-    const canvasEl = document.getElementById(config.qrEl);
-    const qrCodeString = JSON.stringify(qrCodeInfo);
-    QRCode.toCanvas(canvasEl, qrCodeString, { width: 350 });
-  };
-
-  const start = function () {
-    setState(WAIT_FOR_QR_CODE);
-
-    let existingSessionInit = JSON.parse(localStorage.getItem('session_init_info'));
-    if (existingSessionInit) {
-      setQrCode(existingSessionInit.qr_code_info);
-      pollForStatus(existingSessionInit.session_id);
-      return;
-    }
-
-    // show helper after 20 seconds
-    setTimeout(showHelper, 20000);
-
-    let postData = {
-      type: "BehandelaarLogin",
-      language: "NL",
-      version: "v1"
+  const validateToken = async function (token) {
+    // construct body to post to nuts-node
+    const body = {
+      contract_format: 'jwt',
+      contract_string: token,
+      acting_party_cn: actingPartyCN,
     };
 
-    fetch(`${config.nutsAuthUrl}/auth/contract/session`, {
-      method: 'POST',
-      mode: 'cors',
-      headers: {"Content-Type": "application/json"},
-      body: JSON.stringify(postData),
-      cache: 'reload'
-    }).then((result) => result.json()
-    ).then((result) => {
-      // qrCode.makeCode(JSON.stringify(result.qr_code_info));
-      setQrCode(result.qr_code_info);
-      localStorage.setItem('session_init_info', JSON.stringify(result));
-      pollForStatus(result.session_id);
-    }).catch((err) => {
-        console.log("err", err);
-        stateMachine("ERROR");
-      }
-    );
-  };
+    let validationResponse;
 
-
-  const pollForStatus = function (sessionId) {
-    fetchStatus(sessionId)
-      .then((status) => {
-        if (config.logLevel === 'debug') {
-          console.log("state:", status);
-        }
-        stateMachine(status);
-      }).catch((err) => {
-        console.log(err);
-        stateMachine("ERROR");
-      }
-    )
-  };
-
-  // handle these cases: https://godoc.org/github.com/privacybydesign/irmago/server#Status
-  const stateMachine = function (status) {
-    switch (status.status) {
-      case "INITIALIZED":
-        setState(INITIALIZED_STATE);
-        setTimeout(() => pollForStatus(status.token), 1000);
-        break;
-      case "CONNECTED":
-        setState(WAITING_FOR_USER_STATE);
-        setTimeout(() => pollForStatus(status.token), 1000);
-        break;
-      case "TIMEOUT":
-        localStorage.clear();
-        setState(EXPIRED_STATE);
-        break;
-      case "CANCELLED":
-        localStorage.clear();
-        setState(CANCELLED_STATE);
-        break;
-      case "DONE":
-        localStorage.clear();
-        if (status.proofStatus === "VALID") {
-          setState(SUCCESS_STATE);
-          setTimeout(() => handleSuccess(status), 2000)
-        } else {
-          setState(ERROR_STATE);
-        }
-        break;
-      case "ERROR":
-      default:
-        localStorage.clear();
-        setState(ERROR_STATE);
-        break;
+    try {
+      validationResponse = await axios.post(`${serverAddress}/auth/contract/validate`, body)
+    } catch (e) {
+      throw "Something went wrong while validating the token"
     }
-  };
 
-  const handleSuccess = function (status) {
-    fetch(config.postTokenPath, {
-      method: 'POST',
-      headers: {"Content-Type": "application/json"},
-      body: JSON.stringify({nuts_auth_token: status.nuts_auth_token}),
-      cache: 'reload',
-      json: true
-    }).then((res) => {
-      if (config.logLevel === 'debug') {
-        console.log("result", res);
-      }
-      if (res.status === 200) {
-        window.location = config.afterSuccessPath
-      } else {
-        setState(ERROR_STATE);
-      }
-    }).catch((err) => {
-      console.log("error while validating session", err);
-    })
-  };
-
-  const WAIT_FOR_QR_CODE = 'loading';
-  const INITIALIZED_STATE = 'initialized';
-  const WAITING_FOR_USER_STATE = 'waiting-for-user';
-  const SUCCESS_STATE = 'success';
-  const EXPIRED_STATE = 'expired';
-  const CANCELLED_STATE = 'cancelled';
-  const ERROR_STATE = 'errored';
-
-  let currentState;
-
-  const stateEl = function (state) {
-    return document.querySelector(`.irma-web-form .content .${state}`)
-  };
-
-  const setState = function (state) {
-    currentState = state;
-    hideAllStates();
-    stateEl(state).style.display = ""
-  };
-
-  const hideAllStates = function () {
-    document.querySelectorAll(`.irma-web-form .content .centered`).forEach((el) => {
-      el.style.display = 'none'
-    })
+    return validationResponse.data;
   };
 
   return {
-    hideHelper,
-    start,
+    validateToken
   }
+
 };
+
+export default client;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const client = (serverAddress, actingPartyCN) => {
+export function nutsAuthClient(serverAddress, actingPartyCN) {
 
   const validateToken = async function (token) {
     // construct body to post to nuts-node
@@ -24,7 +24,4 @@ const client = (serverAddress, actingPartyCN) => {
   return {
     validateToken
   }
-
-};
-
-export default client;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,11 @@
 const path = require('path');
 
-module.exports = {
+const browserConfig = {
   target: 'web',
   mode: 'production',
-  entry: './src/index.js',
+  entry: './src/browser.js',
   output: {
-    filename: 'index.js',
+    filename: 'browser.js',
     path: path.resolve('dist'),
     library: 'nutsAuth',
   },
@@ -20,5 +20,30 @@ module.exports = {
   },
   resolve: {
     extensions: ['.js'],
-  },
+  }
 };
+
+const nodeConfig = {
+  target: 'node',
+  mode: 'production',
+  entry: './src/index.js',
+  output: {
+    filename: 'index.js',
+    path: path.resolve('dist'),
+    libraryTarget: "commonjs",
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js?$/,
+        exclude: /(node_modules)/,
+        use: 'babel-loader',
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.js'],
+  }
+};
+
+module.exports = [browserConfig, nodeConfig];


### PR DESCRIPTION
Add a NodeJS server side logic for interacting with the nuts auth service.
This PR splits the webpack build into 2 configurations: browser and NodeJS.
It adds a validate option for tokens.